### PR TITLE
introduce CBAS Research repo & dedicated tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Gemfile.lock
 /favicon.ico
 _site/
+.DS_Store

--- a/tab_acknowledgments.md
+++ b/tab_acknowledgments.md
@@ -2,7 +2,7 @@
 title: Acknowledgments
 layout: null
 tab: true
-order: 5
+order: 6
 tags: cbas
 ---
 # CBAS Supporters and Contributors

--- a/tab_contribution.md
+++ b/tab_contribution.md
@@ -2,7 +2,7 @@
 title: Contribution
 layout: null
 tab: true
-order: 6
+order: 7
 tags: cbas
 ---
 # CBAS Contribution Guidelines

--- a/tab_newsandevents.md
+++ b/tab_newsandevents.md
@@ -3,7 +3,7 @@ title: newsandevents
 displaytext: News and Events
 layout: null
 tab: true
-order: 4
+order: 5
 tags: cbas
 ---
 

--- a/tab_research.md
+++ b/tab_research.md
@@ -1,0 +1,8 @@
+---
+title: Research
+layout: null
+tab: true
+order: 4
+tags: cbas
+---
+# CBAS Research

--- a/tab_research.md
+++ b/tab_research.md
@@ -5,4 +5,30 @@ tab: true
 order: 4
 tags: cbas
 ---
-# CBAS Research
+# OWASP CBAS - SAP Security Research
+_A curated collection of findings, PoCs, and tools for advancing SAP Security_
+
+[OWASP CBAS - SAP Security Research Project Page](https://github.com/SecuritySilverbacks/sap-security-research)
+
+> [!Warning]
+> All PoCs and tools are provided **for educational and research purposes only**.
+> You are solely responsible for ensuring you have appropriate authorization before testing against any system.
+>
+> **Never test on production SAP systems without proper approval.**
+
+## About This Repository
+
+This repository is maintained by the [OWASP Core Business Application Security (CBAS)](https://owasp.org/www-project-core-business-application-security/) project and serves as a public archive of research efforts focused on **SAP Security**.
+
+Here we collect:
+
+- **Research Papers & Whitepapers**
+Novel attack vectors, analysis of SAP technologies, and deep-dives into misconfigurations or overlooked weaknesses.
+
+- **Proof-of-Concept Exploits (PoCs)**
+Demonstrative code snippets and reproducible environments for responsible testing and education.
+
+- **Detection & Hardening Tools**
+Scripts and techniques to aid defenders in identifying vulnerable components, misconfigurations, and implementing mitigations.
+
+All contributions are intended to **educate, empower, and protect** the global SAP ecosystem in line with OWASP’s mission.


### PR DESCRIPTION
- add a new tab for the OWASP CBAS Research repo including a mirror of the readme.
- restructure the tabs on the page.
- add `.DS_Store` files to the `.gitignore`